### PR TITLE
feat: add team-season rankings

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,27 +1,201 @@
 # Power Rankings
 
-This project collects fantasy football league data and produces power rankings based on historic
-performance. The CLI can plot season summaries, evaluate all-time rankings, and now automates
-schedule downloads from ESPN using Playwright.
+[![Python 3.12](https://img.shields.io/badge/python-3.12-blue.svg)](pyproject.toml)
+[![Tests](https://img.shields.io/badge/tests-pytest-green.svg)](tests/test_web_fetch.py)
+[![Playwright](https://img.shields.io/badge/ui%20automation-Playwright-purple.svg)](src/power_rankings/web_fetch.py)
 
-## Requirements
+## What the project does
 
-- Python 3.12 (as declared in `pyproject.toml`)
-- Optional: Playwright browsers installed via `playwright install` before running auto-fetch.
+Power Rankings is a Typer-based CLI toolkit for ingesting ESPN fantasy football schedules, computing
+season and multi-season analytics, and exporting summary plots. The core commands live under
+`src/power_rankings/` and share a pipeline that downloads (or reuses cached) ESPN HTML schedules,
+parses weekly matchups into pandas dataframes, and prints tables or plots that highlight actual vs.
+expected wins, luck, points for/against, and team-specific storylines.
 
-## Usage
+## Why the project is useful
 
-- `power-rankings all-time` generates tables and graphs for a range of seasons; pass `--offline`
-  with stored HTML files or omit it to auto-download schedules via ESPN login (see CLI help for
-  credentials, league flags, and headless controls).
-- `power-rankings team-spotlight` and other scripts remain available per `pyproject.toml`.
+- **Automated data collection** – Uses Playwright to log in to ESPN with stored credentials and save
+  each season’s schedule HTML under `html/<league>/<season>.html`, so you always analyze fresh data.
+- **Consistent metrics** – `season_summary.get_summary_table` powers all CLIs, ensuring “Actual” vs.
+  “Expected” wins, “Luck,” `PF/PA`, and top/bottom weekly finishes are comparable across seasons.
+- **Multiple entry points** – Run `power-rankings` for one season, `all-time` for historical rollups,
+  `team-spotlight` for emoji-enhanced narratives, or `team-season-rankings` to compare teams across
+  leagues.
+- **Shareable outputs** – Save plots to `out/` for dashboards or export CSV-like tables directly from
+  the CLI for downstream processing.
 
-## Testing
+## Architecture overview
 
-Run the targeted test suite with:
+Power Rankings uses a shared pipeline to ingest ESPN fantasy schedules, transform them into analytics
+tables, and expose those results through Typer entrypoints.
 
+### High-level flow
+
+- **Fetch or load HTML** – Every CLI funnels through `cli_common.ensure_schedule_or_exit`, which
+  either validates a user-supplied HTML file or triggers Playwright-based scraping
+  (`web_fetch.download_schedule_html`) using credentials and league metadata from `leagues.toml`.
+- **Parse schedule tables** – `parse_utils.get_inputs` loads the stored HTML and uses PyQuery to walk
+  the matchup tables. It emits a normalized pandas `DataFrame` with one row per team per week
+  containing `team`, `opponent`, `score`, `opp_score`, derived `wins`, and the inferred `season`.
+- **Aggregate season metrics** – `season_summary.get_summary_table` slices the dataframe to the
+  requested weeks and computes aggregate statistics (wins/ties/losses, expected wins, luck, PF/PA,
+  weekly top/bottom finishes, etc.). This is the shared core for `power-rankings`, `all-time`, and
+  the plotting helpers.
+- **Present via CLI** – Each entrypoint (`power_rankings.power_rankings`, `power_rankings.all_time`,
+  `power_rankings.team_spotlight`) wires Typer options to the shared helpers and prints/plots the
+  resulting tables.
+
+### CLI entry points
+
+- `power-rankings` – Single-season standings table with optional plots. Handles fetching, week
+  bounds, and printing the summary table.
+- `all-time` – Iterates over a range of seasons, fetches each HTML schedule, aggregates per-manager
+  statistics across seasons, then prints the combined table.
+- `team-spotlight` – Focuses on one manager; shares the same HTML parsing but applies bespoke
+  analysis/visualization (see `team_spotlight.py`).
+- `team-season-rankings` – Compares individual team seasons across leagues and seasons by reusing
+  the shared summary tables.
+
+All CLIs share logging, credential, league, and filesystem options defined in `cli_common.py`,
+keeping UX consistent.
+
+### Data model details
+
+- **Raw rows**: `week`, `team`, `opponent`, `score`, `opp_score`, `wins`, `season`.
+- **Derived aggregates per team (columns from `get_summary_table`)**:
+  - `W`, `T`, `L` – Head-to-head tallies computed against every opponent in the same week.
+  - `Pct` – Expected win percentage (`(W + 0.5*T) / (W + T + L)`).
+  - `Actual` – Real wins from actual match outcomes; treated as ints when there are no ties.
+  - `Exp` – Expected wins over the games played (`Pct * games_played`).
+  - `Luck` – `Actual - Exp`, highlighting over/under-performance.
+  - `Proj` – Projection for the rest of the season based on remaining weeks (14 post-2020, otherwise
+    13).
+  - `PF` / `PA` – Total points for/against.
+  - `Max` / `Min` – Best and worst weekly scores logged by the team.
+  - `Top1`, `Bot1`, `Top3`, `Bot3` – Frequency of finishing in the top/bottom 1 or 3 scores for a
+    given week.
+  - `Carpe` – Ratio of actual wins to the weekly-adjusted expected wins metric.
+
+Downstream tables (CLI prints and optional plots) are sorted by `Pct` descending and rounded to
+three decimals before display.
+
+### Future storage considerations
+
+The current architecture is file-backed: HTML sits under `html/<league>/<season>.html`, derivatives
+live only in memory, and plots go wherever `--out-dir` points. Introducing a database layer will
+mainly affect the “Fetch or load HTML” step; all downstream code already consumes pandas dataframes,
+so a future ingestion pipeline can hydrate the same schema from persisted tables instead of direct
+HTML parsing.
+
+## Getting started
+
+### Prerequisites
+
+- Python 3.12 (enforced by `pyproject.toml`)
+- [uv](https://github.com/astral-sh/uv) for dependency management
+- Chromium browsers installed for Playwright scraping
+- ESPN login with access to the target leagues
+
+### Install dependencies
+
+```bash
+uv sync
+uv run playwright install chromium
 ```
-uv run pytest tests/test_web_fetch.py
+
+`uv sync` installs both runtime and `[dev]` dependencies, so `uv run …` uses the project’s lockfile.
+
+### Configure leagues and credentials
+
+Map friendly league names to ESPN IDs in [`leagues.toml`](leagues.toml):
+
+```toml
+[jlssffl]
+league_id = 329301
 ```
 
-Adjust the command when adding future tests.
+Store ESPN credentials via environment variables or CLI flags:
+
+```bash
+export ESPN_USERNAME="name@example.com"
+export ESPN_PASSWORD="app-specific-password"
+```
+
+Playwright caches login state in `~/.cache/power_rankings/espn_state.json`. If a stored session
+expires, re-run a command with `--headless/--no-headless` as needed or use
+[`debug_storage_state.py`](debug_storage_state.py) to inspect the saved state.
+
+### CLI quick reference
+
+| Command | Purpose | Example |
+| --- | --- | --- |
+| `power-rankings` | Single-season summary with optional plots | `uv run power-rankings --league jlssffl --season 2024 --out-dir out/2024` |
+| `all-time` | Aggregate multiple seasons | `uv run all-time 2019 2024 --league jlssffl --out-dir out/all-time` |
+| `team-spotlight` | Narrative of one owner’s season | `uv run team-spotlight "Matt Goldberg" --league jlssffl --season 2024 --out-dir out/spotlight` |
+| `team-season-rankings` | Cross-league, cross-season comparisons | `uv run team-season-rankings --league jlssffl --league hoedown --start-season 2018 --end-season 2024` |
+
+All commands accept shared options from `cli_common.py`:
+
+- `--offline` – Skip auto-fetching and read a saved HTML file (pass the file path as the positional
+  argument). Cached files live under `html/<league>/`.
+- `--download-dir` – Override where HTML is stored.
+- `--refresh` – Force re-download even when a cached file exists.
+- `--headless/--no-headless` – Control Chromium visibility if manual MFA prompts are expected.
+
+#### Examples
+
+- Use local HTML and create charts:
+
+  ```bash
+  uv run power-rankings html/jlssffl/2023.html --offline --out-dir out/2023
+  ```
+
+- Auto-fetch five years of data and print cumulative standings:
+
+  ```bash
+  uv run all-time 2020 2024 --league jlssffl --download-dir html/jlssffl
+  ```
+
+- Compare every stored team season, sorted by `Proj` and limited to games through Week 10:
+
+  ```bash
+  uv run team-season-rankings --league jlssffl --end-week 10 --sort-column Proj --sort-direction desc
+  ```
+
+### Testing and quality checks
+
+```bash
+uv run pytest          # entire suite
+uv run pytest tests/test_web_fetch.py  # focused Playwright mocks
+uv run black src tests
+uv run ruff check src tests
+```
+
+`tests/test_web_fetch.py` demonstrates how network calls are mocked; follow that pattern for any new
+automation logic. Save generated plots to `out/` and keep deterministic fixtures (if needed) under
+`tests/fixtures/`.
+
+## Where to get help
+
+- [Architecture overview](#architecture-overview) – Data flow, CLI interactions, and data model.
+- [AGENTS.md](AGENTS.md) – Repository conventions, testing requirements, and release expectations.
+- [`debug_storage_state.py`](debug_storage_state.py) – Diagnose Playwright login sessions.
+- [`tests/test_web_fetch.py`](tests/test_web_fetch.py) – Reference for stubbing ESPN scraping.
+- File an issue or start a discussion in the repository when you need new league metadata, CLI
+  flags, or help debugging Playwright.
+
+## Who maintains and contributes
+
+The project is maintained by Matthew Goldberg and an open-source contributor group focused on
+fantasy analytics tooling. Contributions are welcome:
+
+1. Review the guidelines in [AGENTS.md](AGENTS.md) (structure, style, testing, conventional commits).
+2. Create a feature branch, make focused changes, and update relevant docs (README, ARCHITECTURE,
+   etc.).
+3. Run `uv run pytest -k <target> --maxfail=1`, plus `uv run black` and `uv run ruff`, before
+   opening a pull request.
+4. Use descriptive commit messages (`feat(all-time): add SOS projection`) and document any data
+   prerequisites (league IDs, HTML fixtures, screenshots from `out/`).
+
+For questions about roadmap or release cadence, open a GitHub issue and tag @matthew-goldberg (or
+the current maintainer) to start the conversation.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,6 +24,7 @@ dependencies = [
 scripts.all-time = "power_rankings.all_time:cli"
 scripts.power-rankings = "power_rankings.power_rankings:cli"
 scripts.team-spotlight = "power_rankings.team_spotlight:cli"
+scripts.team-season-rankings = "power_rankings.team_season_rankings:cli"
 
 [dependency-groups]
 dev = [

--- a/src/power_rankings/name_utils.py
+++ b/src/power_rankings/name_utils.py
@@ -1,0 +1,49 @@
+from __future__ import annotations
+
+from typing import Any
+
+import pandas as pd
+
+DUPES: dict[str, str] = {
+    "MATTHEW GOLDBERG": "Matt Goldberg",
+    "mitch hildreth, I. Reese": "mitch hildreth",
+    "Joe Gowetski": "Joseph Gowetski",
+    "Chris Ptak": "Christopher Ptak",
+}
+
+
+def canonical_team_label(name: Any) -> Any:
+    """
+    Map a raw team name to its canonical identifier.
+
+    Non-string values (e.g., NaN) are returned unchanged.
+    """
+    if not isinstance(name, str):
+        return name
+    return DUPES.get(name, name)
+
+
+def canonicalize_team_names(df: pd.DataFrame) -> tuple[pd.DataFrame, dict[str, str]]:
+    """
+    Replace duplicate/legacy team labels with canonical identifiers while tracking
+    the most recently observed display name for each team.
+
+    Returns a tuple of (normalized dataframe, display name map).
+    """
+    if df.empty:
+        return df.copy(), {}
+
+    normalized = df.copy()
+    order_cols = [col for col in ("season", "week") if col in normalized.columns]
+    sorted_df = normalized.sort_values(order_cols) if order_cols else normalized
+
+    latest_display: dict[str, str] = {}
+    for _, row in sorted_df.iterrows():
+        team_name = row["team"]
+        canonical = canonical_team_label(team_name)
+        if isinstance(canonical, str) and isinstance(team_name, str):
+            latest_display[canonical] = team_name
+
+    normalized["team"] = normalized["team"].map(canonical_team_label)
+    normalized["opponent"] = normalized["opponent"].map(canonical_team_label)
+    return normalized, latest_display

--- a/src/power_rankings/power_rankings.py
+++ b/src/power_rankings/power_rankings.py
@@ -3,6 +3,7 @@ from pathlib import Path
 import typer
 
 from power_rankings import cli_common
+from power_rankings.name_utils import canonicalize_team_names
 from power_rankings.parse_utils import get_inputs, most_recent_week
 from power_rankings.season_summary import get_summary_table, plot_season_graphs
 
@@ -51,6 +52,7 @@ def main(
     )
 
     df = get_inputs(html_path)
+    df, display_names = canonicalize_team_names(df)
 
     if start_week is None:
         start_week = 1
@@ -62,6 +64,7 @@ def main(
         end_week = min(end_week, most_recent)
 
     summary_table = get_summary_table(df, start_week, end_week)
+    summary_table = summary_table.rename(index=lambda name: display_names.get(name, name))
 
     if out_dir is not None:
         plot_season_graphs(df, start_week, end_week, out_dir)

--- a/src/power_rankings/team_season_rankings.py
+++ b/src/power_rankings/team_season_rankings.py
@@ -1,0 +1,250 @@
+from __future__ import annotations
+
+import logging
+import re
+from pathlib import Path
+from typing import Iterable
+
+import pandas as pd
+import typer
+
+from power_rankings import cli_common
+from power_rankings.league_config import load_league_mapping
+from power_rankings.name_utils import canonicalize_team_names
+from power_rankings.parse_utils import get_inputs, most_recent_week
+from power_rankings.season_summary import get_summary_table
+
+logger = logging.getLogger(__name__)
+
+
+def main(
+    start_season: int | None = typer.Option(
+        None,
+        "--start-season",
+        help="Earliest season (year) to include.",
+    ),
+    end_season: int | None = typer.Option(
+        None,
+        "--end-season",
+        help="Latest season (year) to include.",
+    ),
+    leagues: list[str] | None = typer.Option(
+        None,
+        "--league",
+        "-l",
+        help="League name from leagues.toml. Repeat the option to include multiple leagues.",
+        show_default=False,
+        rich_help_panel="Filters",
+    ),
+    end_week: int | None = typer.Option(
+        None,
+        "--end-week",
+        min=1,
+        max=18,
+        help="Cutoff week (inclusive) when computing each season summary.",
+    ),
+    sort_column: str = typer.Option(
+        "Pct",
+        "--sort-column",
+        help="Output column to sort by. Must match one of the table headers.",
+    ),
+    sort_direction: str = typer.Option(
+        "desc",
+        "--sort-direction",
+        help="Sorting direction for the selected column (asc or desc).",
+    ),
+    offline: bool = cli_common.offline_option(),
+    download_dir: Path | None = cli_common.download_dir_option(),
+    leagues_file: Path | None = cli_common.leagues_file_option(),
+    refresh: bool = cli_common.refresh_option(),
+    headless: bool = cli_common.headless_option(default=True),
+    username: str | None = cli_common.username_option(),
+    password: str | None = cli_common.password_option(),
+    log_level: str = cli_common.log_level_option(),
+):
+    """Compare team seasons across one or more leagues."""
+    cli_common.configure_logging(log_level)
+    auto_fetch = cli_common.resolve_auto_fetch(offline)
+    sort_dir = _normalize_sort_direction(sort_direction)
+
+    league_mapping = load_league_mapping(leagues_file)
+    selected_leagues = _resolve_leagues(leagues, league_mapping)
+
+    seasons = _resolve_seasons(start_season, end_season, selected_leagues, download_dir)
+    if not seasons:
+        typer.secho("No seasons to process; provide --start-season/--end-season or download HTML first.", fg="red", err=True)
+        raise typer.Exit(code=2)
+
+    frames: list[pd.DataFrame] = []
+    latest_names: dict[str, tuple[int, str]] = {}
+    for league_name in selected_leagues:
+        for season in seasons:
+            season_dir = _season_dir(league_name, download_dir)
+            html_arg = None if auto_fetch else season_dir / f"{season}.html"
+            try:
+                resolved_html = cli_common.ensure_schedule_or_exit(
+                    html_arg,
+                    auto_fetch=auto_fetch,
+                    league_id=None,
+                    league_name=league_name,
+                    leagues_file=leagues_file,
+                    season=season,
+                    download_dir=season_dir,
+                    force_refresh=refresh,
+                    headless=headless,
+                    username=username,
+                    password=password,
+                )
+            except typer.Exit:
+                raise
+            except Exception as exc:  # noqa: BLE001
+                logger.error(
+                    "Failed to retrieve schedule for league '%s' season %s: %s",
+                    league_name,
+                    season,
+                    exc,
+                    exc_info=True,
+                )
+                raise
+
+            season_summary, season_display = _build_team_season_summary(resolved_html, end_week)
+            for canonical, display in season_display.items():
+                existing = latest_names.get(canonical)
+                if existing is None or season >= existing[0]:
+                    latest_names[canonical] = (season, display)
+
+            if season_summary.empty:
+                logger.info(
+                    "Season %s for league '%s' has no completed weeks; skipping.",
+                    season,
+                    league_name,
+                )
+                continue
+            season_summary.insert(0, "Season", season)
+            season_summary.insert(1, "Team", season_summary.pop("Team"))
+            frames.append(season_summary)
+
+    if not frames:
+        typer.secho("No completed team seasons were found for the requested filters.", fg="yellow")
+        raise typer.Exit(code=0)
+
+    combined = pd.concat(frames, ignore_index=True)
+    display_lookup = {team: display for team, (_, display) in latest_names.items()}
+    combined["Team"] = combined["Team"].map(lambda name: display_lookup.get(name, name))
+    if sort_column not in combined.columns:
+        raise ValueError(
+            f"sort_column '{sort_column}' must be one of: {', '.join(combined.columns)}"
+        )
+    ascending = sort_dir == "asc"
+    combined = combined.sort_values(sort_column, ascending=ascending).reset_index(drop=True)
+
+    pd.set_option("display.max_rows", 200)
+    print()
+    print(combined)
+    print()
+
+
+def _normalize_sort_direction(direction: str) -> str:
+    norm = (direction or "").strip().lower()
+    if norm not in ("asc", "desc"):
+        raise typer.BadParameter("sort-direction must be either 'asc' or 'desc'.")
+    return norm
+
+
+def _resolve_leagues(
+    requested: Iterable[str] | None,
+    mapping: dict[str, int],
+) -> list[str]:
+    if not mapping:
+        raise typer.BadParameter(
+            "No leagues are configured. Create leagues.toml or pass --leagues-file."
+        )
+
+    if not requested:
+        return sorted(mapping.keys())
+
+    normalized_order = list(dict.fromkeys(requested))
+    missing = [name for name in normalized_order if name not in mapping]
+    if missing:
+        raise typer.BadParameter(
+            f"Unknown league(s): {', '.join(missing)}. Available: {', '.join(sorted(mapping))}"
+        )
+    return normalized_order
+
+
+def _resolve_seasons(
+    start: int | None,
+    end: int | None,
+    leagues: Iterable[str],
+    download_root: Path | None,
+) -> list[int]:
+    if start is not None or end is not None:
+        if start is None:
+            start = end
+        if end is None:
+            end = start
+        assert start is not None and end is not None
+        if start > end:
+            raise typer.BadParameter("--start-season cannot be greater than --end-season.")
+        return list(range(start, end + 1))
+
+    seasons: set[int] = set()
+    for league in leagues:
+        seasons.update(_discover_available_seasons(league, download_root))
+    return sorted(seasons)
+
+
+def _discover_available_seasons(league: str, download_root: Path | None) -> set[int]:
+    base = _base_download_dir(download_root) / league
+    if not base.exists():
+        return set()
+    seasons: set[int] = set()
+    pattern = re.compile(r"(20\d{2})")
+    for html_file in base.glob("*.html"):
+        match = pattern.search(html_file.name)
+        if match:
+            seasons.add(int(match.group(1)))
+    return seasons
+
+
+def _build_team_season_summary(
+    html_path: Path, requested_end_week: int | None
+) -> tuple[pd.DataFrame, dict[str, str]]:
+    df = get_inputs(html_path)
+    df, display_names = canonicalize_team_names(df)
+    if df.empty:
+        return pd.DataFrame(), {}
+
+    season_year = int(df["season"].unique().item())
+    default_last_week = 14 if season_year > 2020 else 13
+    most_recent = most_recent_week(df)
+    cutoff = min(most_recent, default_last_week)
+    if requested_end_week is not None:
+        cutoff = min(cutoff, requested_end_week)
+    if cutoff < 1:
+        return pd.DataFrame(), {}
+
+    summary = get_summary_table(df, 1, cutoff)
+    summary = summary.reset_index().rename(columns={"index": "Team"})
+    ordered_cols = ["Team"] + [col for col in summary.columns if col != "Team"]
+    return summary.loc[:, ordered_cols], display_names
+
+
+def _season_dir(league: str, download_root: Path | None) -> Path:
+    base_dir = _base_download_dir(download_root) / league
+    base_dir.mkdir(parents=True, exist_ok=True)
+    return base_dir
+
+
+def _base_download_dir(download_root: Path | None) -> Path:
+    if download_root is not None:
+        return download_root
+    return Path("html")
+
+
+def cli():
+    typer.run(main)
+
+
+if __name__ == "__main__":
+    cli()


### PR DESCRIPTION
## Summary
- add a canonical name helper so all CLIs display the most recent label
- add the  CLI with multi-league filtering, sorting, and refresh support plus pandas display tweaks
- document the architecture and new CLI usage in ARCHITECTURE.md and README.md

## Testing
-                                                                                 
 Usage: python -m power_rankings.team_season_rankings [OPTIONS]                 
                                                                                
 Compare team seasons across one or more leagues.                               
                                                                                
╭─ Options ────────────────────────────────────────────────────────────────────╮
│ --start-season                       INTEGER             Earliest season     │
│                                                          (year) to include.  │
│ --end-season                         INTEGER             Latest season       │
│                                                          (year) to include.  │
│ --end-week                           INTEGER RANGE       Cutoff week         │
│                                      [1<=x<=18]          (inclusive) when    │
│                                                          computing each      │
│                                                          season summary.     │
│ --sort-column                        TEXT                Output column to    │
│                                                          sort by. Must match │
│                                                          one of the table    │
│                                                          headers.            │
│                                                          [default: Pct]      │
│ --sort-direction                     TEXT                Sorting direction   │
│                                                          for the selected    │
│                                                          column (asc or      │
│                                                          desc).              │
│                                                          [default: desc]     │
│ --offline                                                Skip downloading    │
│                                                          schedules; requires │
│                                                          local HTML files.   │
│ --download-dir                       DIRECTORY           Directory to store  │
│                                                          downloaded HTML     │
│                                                          (defaults to        │
│                                                          html/<league>/).    │
│ --leagues-file                       FILE                Path to             │
│                                                          leagues.toml        │
│                                                          mapping league      │
│                                                          names to IDs.       │
│ --refresh                                                Force re-download   │
│                                                          even if a cached    │
│                                                          file exists.        │
│ --headless          --no-headless                        Run the browser in  │
│                                                          headless mode while │
│                                                          auto-fetching.      │
│                                                          [default: headless] │
│ --username                           TEXT                ESPN username/email │
│                                                          (overrides          │
│                                                          ESPN_USERNAME env   │
│                                                          var).               │
│ --password                           TEXT                ESPN password       │
│                                                          (overrides          │
│                                                          ESPN_PASSWORD env   │
│                                                          var).               │
│ --log-level                          TEXT                Logging verbosity   │
│                                                          (choose from:       │
│                                                          debug, info,        │
│                                                          warning, error,     │
│                                                          critical).          │
│                                                          [default: info]     │
│ --help                                                   Show this message   │
│                                                          and exit.           │
╰──────────────────────────────────────────────────────────────────────────────╯
╭─ Filters ────────────────────────────────────────────────────────────────────╮
│ --league  -l      TEXT  League name from leagues.toml. Repeat the option to  │
│                         include multiple leagues.                            │
╰──────────────────────────────────────────────────────────────────────────────╯