### PR TITLE
feat(cli): migrate parsing from typer to cyclopts

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ dependencies = [
   "pyquery>=0.13.2",
   "seaborn>=0.12.1,<0.13",
   "playwright>=1.47",
-  "typer>=0.19",
+  "cyclopts>=4.2",
 ]
 
 scripts.all-time = "power_rankings.all_time:cli"

--- a/src/power_rankings/power_rankings.py
+++ b/src/power_rankings/power_rankings.py
@@ -1,6 +1,8 @@
 from pathlib import Path
+from typing import Annotated
 
-import typer
+from cyclopts import Parameter, run
+from cyclopts.validators import Path as PathValidator
 
 from power_rankings import cli_common
 from power_rankings.name_utils import canonicalize_team_names
@@ -9,29 +11,36 @@ from power_rankings.season_summary import get_summary_table, plot_season_graphs
 
 
 def main(
-    html_filename: Path | None = typer.Argument(None, dir_okay=False),
-    out_dir: Path | None = typer.Option(
-        None,
-        "--out-dir",
-        file_okay=False,
-        help="Directory to store generated plots.",
-    ),
-    start_week: int | None = None,
-    end_week: int | None = None,
-    offline: bool = cli_common.offline_option(),
-    league: str | None = cli_common.league_option(),
-    league_id: int | None = cli_common.league_id_option(),
-    season: int | None = cli_common.season_option(),
-    download_dir: Path | None = cli_common.download_dir_option(),
-    leagues_file: Path | None = cli_common.leagues_file_option(),
-    refresh: bool = cli_common.refresh_option(),
-    headless: bool = cli_common.headless_option(default=False),
-    username: str | None = cli_common.username_option(),
-    password: str | None = cli_common.password_option(),
-    log_level: str = cli_common.log_level_option(),
-):
-    """Generates rankings for a given season, given the HTML of the schedule
-    and results."""
+    html_filename: Annotated[
+        Path | None,
+        Parameter(
+            help="Path to a saved schedule HTML file; auto-downloads if omitted.",
+            validator=PathValidator(dir_okay=False),
+        ),
+    ] = None,
+    out_dir: Annotated[
+        Path | None,
+        Parameter(
+            help="Directory to store generated plots.",
+            validator=PathValidator(file_okay=False),
+        ),
+    ] = None,
+    start_week: Annotated[int | None, Parameter(help="First week (inclusive).")] = None,
+    end_week: Annotated[int | None, Parameter(help="Last week (inclusive).")] = None,
+    offline: Annotated[bool, cli_common.offline_option()] = False,
+    league: Annotated[str | None, cli_common.league_option()] = None,
+    league_id: Annotated[int | None, cli_common.league_id_option()] = None,
+    season: Annotated[int | None, cli_common.season_option()] = None,
+    download_dir: Annotated[Path | None, cli_common.download_dir_option()] = None,
+    leagues_file: Annotated[Path | None, cli_common.leagues_file_option()] = None,
+    refresh: Annotated[bool, cli_common.refresh_option()] = False,
+    headless: Annotated[bool, cli_common.headless_option()] = False,
+    username: Annotated[str | None, cli_common.username_option()] = None,
+    password: Annotated[str | None, cli_common.password_option()] = None,
+    log_level: Annotated[str, cli_common.log_level_option()] = "info",
+) -> None:
+    """Generates rankings for a given season, given the HTML of the schedule and results."""
+    log_level = cli_common.normalize_log_level(log_level)
     cli_common.configure_logging(log_level)
 
     auto_fetch = cli_common.resolve_auto_fetch(offline)
@@ -74,8 +83,8 @@ def main(
     print()
 
 
-def cli():
-    typer.run(main)
+def cli() -> None:
+    run(main)
 
 
 if __name__ == "__main__":

--- a/src/power_rankings/team_spotlight.py
+++ b/src/power_rankings/team_spotlight.py
@@ -1,6 +1,8 @@
 from pathlib import Path
+from typing import Annotated
 
-import typer
+from cyclopts import Parameter, run
+from cyclopts.validators import Path as PathValidator
 
 from power_rankings import cli_common
 from power_rankings.name_utils import canonical_team_label, canonicalize_team_names
@@ -9,24 +11,36 @@ from power_rankings.parse_utils import get_inputs, most_recent_week
 
 def main(
     owner_name: str,
-    html_filename: Path | None = typer.Argument(None, dir_okay=False),
-    out_dir: Path | None = typer.Argument(None, file_okay=False),
-    start_week: int | None = None,
-    end_week: int | None = None,
-    offline: bool = cli_common.offline_option(),
-    league: str | None = cli_common.league_option(),
-    league_id: int | None = cli_common.league_id_option(),
-    season: int | None = cli_common.season_option(),
-    download_dir: Path | None = cli_common.download_dir_option(),
-    leagues_file: Path | None = cli_common.leagues_file_option(),
-    refresh: bool = cli_common.refresh_option(),
-    headless: bool = cli_common.headless_option(default=True),
-    username: str | None = cli_common.username_option(),
-    password: str | None = cli_common.password_option(),
-    log_level: str = cli_common.log_level_option(),
-):
-    """Generates rankings for a given season, given the HTML of the schedule
-    and results."""
+    html_filename: Annotated[
+        Path | None,
+        Parameter(
+            help="Path to a saved schedule HTML file; auto-downloads if omitted.",
+            validator=PathValidator(dir_okay=False),
+        ),
+    ] = None,
+    out_dir: Annotated[
+        Path | None,
+        Parameter(
+            help="Directory to store generated plots (optional).",
+            validator=PathValidator(file_okay=False),
+        ),
+    ] = None,
+    start_week: Annotated[int | None, Parameter(help="First week (inclusive).")] = None,
+    end_week: Annotated[int | None, Parameter(help="Last week (inclusive).")] = None,
+    offline: Annotated[bool, cli_common.offline_option()] = False,
+    league: Annotated[str | None, cli_common.league_option()] = None,
+    league_id: Annotated[int | None, cli_common.league_id_option()] = None,
+    season: Annotated[int | None, cli_common.season_option()] = None,
+    download_dir: Annotated[Path | None, cli_common.download_dir_option()] = None,
+    leagues_file: Annotated[Path | None, cli_common.leagues_file_option()] = None,
+    refresh: Annotated[bool, cli_common.refresh_option()] = False,
+    headless: Annotated[bool, cli_common.headless_option()] = True,
+    username: Annotated[str | None, cli_common.username_option()] = None,
+    password: Annotated[str | None, cli_common.password_option()] = None,
+    log_level: Annotated[str, cli_common.log_level_option()] = "info",
+) -> None:
+    """Generates rankings for a given season, given the HTML of the schedule and results."""
+    log_level = cli_common.normalize_log_level(log_level)
     cli_common.configure_logging(log_level)
 
     auto_fetch = cli_common.resolve_auto_fetch(offline)
@@ -124,8 +138,8 @@ def main(
         print()
 
 
-def cli():
-    typer.run(main)
+def cli() -> None:
+    run(main)
 
 
 if __name__ == "__main__":

--- a/uv.lock
+++ b/uv.lock
@@ -290,6 +290,21 @@ wheels = [
 ]
 
 [[package]]
+name = "cyclopts"
+version = "4.2.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "attrs" },
+    { name = "docstring-parser" },
+    { name = "rich" },
+    { name = "rich-rst" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/34/ab/67bd1b010aaa09c6b627a535cbb0c6453920c290df83cbdccb0b097227d9/cyclopts-4.2.2.tar.gz", hash = "sha256:d5eb7d5ab688f8e86bc6fc7b8ab85951b2fe34aebcf1a48c4c9a6b43c14cb78b", size = 148736, upload-time = "2025-11-10T15:29:46.195Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ac/cc/53c8350d8ca53ada627f071c252e806b97c949e03b054af7d15e62309a83/cyclopts-4.2.2-py3-none-any.whl", hash = "sha256:2e001158ccb275723a4d820c65d114caa078073e61298f2a7c6112a8d3ba90c6", size = 184362, upload-time = "2025-11-10T15:29:44.984Z" },
+]
+
+[[package]]
 name = "debugpy"
 version = "1.8.17"
 source = { registry = "https://pypi.org/simple" }
@@ -327,6 +342,24 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/96/8e/709914eb2b5749865801041647dc7f4e6d00b549cfe88b65ca192995f07c/distlib-0.4.0.tar.gz", hash = "sha256:feec40075be03a04501a973d81f633735b4b69f98b05450592310c0f401a4e0d", size = 614605, upload-time = "2025-07-17T16:52:00.465Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/33/6b/e0547afaf41bf2c42e52430072fa5658766e3d65bd4b03a563d1b6336f57/distlib-0.4.0-py2.py3-none-any.whl", hash = "sha256:9659f7d87e46584a30b5780e43ac7a2143098441670ff0a49d5f9034c54a6c16", size = 469047, upload-time = "2025-07-17T16:51:58.613Z" },
+]
+
+[[package]]
+name = "docstring-parser"
+version = "0.17.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/b2/9d/c3b43da9515bd270df0f80548d9944e389870713cc1fe2b8fb35fe2bcefd/docstring_parser-0.17.0.tar.gz", hash = "sha256:583de4a309722b3315439bb31d64ba3eebada841f2e2cee23b99df001434c912", size = 27442, upload-time = "2025-07-21T07:35:01.868Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/55/e2/2537ebcff11c1ee1ff17d8d0b6f4db75873e3b0fb32c2d4a2ee31ecb310a/docstring_parser-0.17.0-py3-none-any.whl", hash = "sha256:cf2569abd23dce8099b300f9b4fa8191e9582dda731fd533daf54c4551658708", size = 36896, upload-time = "2025-07-21T07:35:00.684Z" },
+]
+
+[[package]]
+name = "docutils"
+version = "0.22.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d9/02/111134bfeb6e6c7ac4c74594e39a59f6c0195dc4846afbeac3cba60f1927/docutils-0.22.3.tar.gz", hash = "sha256:21486ae730e4ca9f622677b1412b879af1791efcfba517e4c6f60be543fc8cdd", size = 2290153, upload-time = "2025-11-06T02:35:55.655Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/11/a8/c6a4b901d17399c77cd81fb001ce8961e9f5e04d3daf27e8925cb012e163/docutils-0.22.3-py3-none-any.whl", hash = "sha256:bd772e4aca73aff037958d44f2be5229ded4c09927fcf8690c577b66234d6ceb", size = 633032, upload-time = "2025-11-06T02:35:52.391Z" },
 ]
 
 [[package]]
@@ -1256,13 +1289,13 @@ version = "0.1.0"
 source = { editable = "." }
 dependencies = [
     { name = "click" },
+    { name = "cyclopts" },
     { name = "matplotlib" },
     { name = "numpy" },
     { name = "pandas" },
     { name = "playwright" },
     { name = "pyquery" },
     { name = "seaborn" },
-    { name = "typer" },
 ]
 
 [package.dev-dependencies]
@@ -1280,13 +1313,13 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "click", specifier = ">=8.1.7" },
+    { name = "cyclopts", specifier = ">=4.2" },
     { name = "matplotlib", specifier = ">=3.9.2" },
     { name = "numpy", specifier = ">=1.23.5,<2" },
     { name = "pandas", specifier = ">=1.5.2,<2" },
     { name = "playwright", specifier = ">=1.47" },
     { name = "pyquery", specifier = ">=0.13.2" },
     { name = "seaborn", specifier = ">=0.12.1,<0.13" },
-    { name = "typer", specifier = ">=0.19" },
 ]
 
 [package.metadata.requires-dev]
@@ -1630,6 +1663,19 @@ wheels = [
 ]
 
 [[package]]
+name = "rich-rst"
+version = "1.3.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "docutils" },
+    { name = "rich" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/bc/6d/a506aaa4a9eaa945ed8ab2b7347859f53593864289853c5d6d62b77246e0/rich_rst-1.3.2.tar.gz", hash = "sha256:a1196fdddf1e364b02ec68a05e8ff8f6914fee10fbca2e6b6735f166bb0da8d4", size = 14936, upload-time = "2025-10-14T16:49:45.332Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/13/2f/b4530fbf948867702d0a3f27de4a6aab1d156f406d72852ab902c4d04de9/rich_rst-1.3.2-py3-none-any.whl", hash = "sha256:a99b4907cbe118cf9d18b0b44de272efa61f15117c61e39ebdc431baf5df722a", size = 12567, upload-time = "2025-10-14T16:49:42.953Z" },
+]
+
+[[package]]
 name = "rpds-py"
 version = "0.27.1"
 source = { registry = "https://pypi.org/simple" }
@@ -1708,15 +1754,6 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/18/5d/3bf57dcd21979b887f014ea83c24ae194cfcd12b9e0fda66b957c69d1fca/setuptools-80.9.0.tar.gz", hash = "sha256:f36b47402ecde768dbfafc46e8e4207b4360c654f1f3bb84475f0a28628fb19c", size = 1319958, upload-time = "2025-05-27T00:56:51.443Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/a3/dc/17031897dae0efacfea57dfd3a82fdd2a2aeb58e0ff71b77b87e44edc772/setuptools-80.9.0-py3-none-any.whl", hash = "sha256:062d34222ad13e0cc312a4c02d73f059e86a4acbfbdea8f8f76b28c99f306922", size = 1201486, upload-time = "2025-05-27T00:56:49.664Z" },
-]
-
-[[package]]
-name = "shellingham"
-version = "1.5.4"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/58/15/8b3609fd3830ef7b27b655beb4b4e9c62313a4e8da8c676e142cc210d58e/shellingham-1.5.4.tar.gz", hash = "sha256:8dbca0739d487e5bd35ab3ca4b36e11c4078f3a234bfce294b0a0291363404de", size = 10310, upload-time = "2023-10-24T04:13:40.426Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/e0/f9/0595336914c5619e5f28a1fb793285925a8cd4b432c9da0a987836c7f822/shellingham-1.5.4-py2.py3-none-any.whl", hash = "sha256:7ecfff8f2fd72616f7481040475a65b2bf8af90a56c89140852d1120324e8686", size = 9755, upload-time = "2023-10-24T04:13:38.866Z" },
 ]
 
 [[package]]
@@ -1812,21 +1849,6 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/eb/79/72064e6a701c2183016abbbfedaba506d81e30e232a68c9f0d6f6fcd1574/traitlets-5.14.3.tar.gz", hash = "sha256:9ed0579d3502c94b4b3732ac120375cda96f923114522847de4b3bb98b96b6b7", size = 161621, upload-time = "2024-04-19T11:11:49.746Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/00/c0/8f5d070730d7836adc9c9b6408dec68c6ced86b304a9b26a14df072a6e8c/traitlets-5.14.3-py3-none-any.whl", hash = "sha256:b74e89e397b1ed28cc831db7aea759ba6640cb3de13090ca145426688ff1ac4f", size = 85359, upload-time = "2024-04-19T11:11:46.763Z" },
-]
-
-[[package]]
-name = "typer"
-version = "0.19.2"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "click" },
-    { name = "rich" },
-    { name = "shellingham" },
-    { name = "typing-extensions" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/21/ca/950278884e2ca20547ff3eb109478c6baf6b8cf219318e6bc4f666fad8e8/typer-0.19.2.tar.gz", hash = "sha256:9ad824308ded0ad06cc716434705f691d4ee0bfd0fb081839d2e426860e7fdca", size = 104755, upload-time = "2025-09-23T09:47:48.256Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/00/22/35617eee79080a5d071d0f14ad698d325ee6b3bf824fc0467c03b30e7fa8/typer-0.19.2-py3-none-any.whl", hash = "sha256:755e7e19670ffad8283db353267cb81ef252f595aa6834a0d1ca9312d9326cb9", size = 46748, upload-time = "2025-09-23T09:47:46.777Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary\n- replace Typer entrypoints with Cyclopts -annotated functions backed by \n- centralize shared CLI helpers and error handling for Cyclopts and keep documentation/dependencies in sync\n\n## Testing\n- Usage: power-rankings [ARGS]

Generates rankings for a given season, given the HTML of the schedule and       
results.

╭─ Commands ───────────────────────────────────────────────────────────────────╮
│ --help -h  Display this message and exit.                                    │
│ --version  Display application version.                                      │
╰──────────────────────────────────────────────────────────────────────────────╯
╭─ Parameters ─────────────────────────────────────────────────────────────────╮
│ HTML-FILENAME                Path to a saved schedule HTML file;             │
│   --html-filename            auto-downloads if omitted.                      │
│ OUT-DIR --out-dir            Directory to store generated plots.             │
│ START-WEEK --start-week      First week (inclusive).                         │
│ END-WEEK --end-week          Last week (inclusive).                          │
│ OFFLINE --offline            Skip downloading schedules; requires local HTML │
│   --no-offline               files. [default: False]                         │
│ LEAGUE --league              League name (from leagues.toml) used when       │
│                              downloading schedules.                          │
│ LEAGUE-ID --league-id        ESPN league identifier to fetch when            │
│                              auto-fetching.                                  │
│ SEASON --season              Season (year) to fetch when auto-fetching.      │
│                              Defaults to current year.                       │
│ DOWNLOAD-DIR --download-dir                                                  │
│                              Directory to store downloaded HTML (defaults to │
│                              html//).                                        │
│ LEAGUES-FILE --leagues-file  Path to leagues.toml mapping league names to    │
│                              IDs.                                            │
│ REFRESH --refresh            Force re-download even if a cached file exists. │
│   --no-refresh               [default: False]                                │
│ HEADLESS --headless          Run the browser in headless mode while          │
│   --no-headless              auto-fetching. [default: False]                 │
│ USERNAME --username          ESPN username/email (overrides ESPN_USERNAME    │
│                              env var).                                       │
│ PASSWORD --password          ESPN password (overrides ESPN_PASSWORD env      │
│                              var).                                           │
│ LOG-LEVEL --log-level        Logging verbosity (choose from: debug, info,    │
│                              warning, error, critical). [default: info]      │
╰──────────────────────────────────────────────────────────────────────────────╯\n- Usage: team-season-rankings [ARGS]

Compare team seasons across one or more leagues.

╭─ Commands ───────────────────────────────────────────────────────────────────╮
│ --help -h  Display this message and exit.                                    │
│ --version  Display application version.                                      │
╰──────────────────────────────────────────────────────────────────────────────╯
╭─ Parameters ─────────────────────────────────────────────────────────────────╮
│ START-SEASON --start-season  Earliest season (year) to include.              │
│ END-SEASON --end-season      Latest season (year) to include.                │
│ LEAGUE --league              League name from leagues.toml. Repeat the       │
│   --empty-league -l          option to include multiple leagues.             │
│ END-WEEK --end-week          Cutoff week (inclusive) when computing each     │
│                              season summary.                                 │
│ SORT-COLUMN --sort-column    Output column to sort by. Must match one of the │
│                              table headers. [default: Pct]                   │
│ SORT-DIRECTION               Sorting direction for the selected column (asc  │
│   --sort-direction           or desc). [default: desc]                       │
│ OFFLINE --offline            Skip downloading schedules; requires local HTML │
│   --no-offline               files. [default: False]                         │
│ DOWNLOAD-DIR --download-dir                                                  │
│                              Directory to store downloaded HTML (defaults to │
│                              html//).                                        │
│ LEAGUES-FILE --leagues-file  Path to leagues.toml mapping league names to    │
│                              IDs.                                            │
│ REFRESH --refresh            Force re-download even if a cached file exists. │
│   --no-refresh               [default: False]                                │
│ HEADLESS --headless          Run the browser in headless mode while          │
│   --no-headless              auto-fetching. [default: True]                  │
│ USERNAME --username          ESPN username/email (overrides ESPN_USERNAME    │
│                              env var).                                       │
│ PASSWORD --password          ESPN password (overrides ESPN_PASSWORD env      │
│                              var).                                           │
│ LOG-LEVEL --log-level        Logging verbosity (choose from: debug, info,    │
│                              warning, error, critical). [default: info]      │
╰──────────────────────────────────────────────────────────────────────────────╯