### PR TITLE
Switch league configuration to YAML

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ notebooks/
 .venv/
 Session.vim
 .env
+leagues.yaml

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,7 +5,7 @@ CLI entry points and shared helpers live under `src/power_rankings/`: `power_ran
 `all_time.py` expose Typer commands, `team_spotlight.py` and `team_season_rankings.py` drive
 story-driven outputs, `cli_common.py` coordinates ESPN scraping, while `season_summary.py` and
 `parse_utils.py` handle analytics. Cached HTML is stored at `html/<league>/<season>.html`; derived
-plots or tables go to `out/`. League metadata sits in `leagues.toml`, and notebook experiments stay
+plots or tables go to `out/`. League metadata sits in `leagues.yaml`, and notebook experiments stay
 in `model.ipynb`. Tests mirror the package layout inside `tests/`, with fixtures near the specs they
 serve.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -33,7 +33,7 @@ so CLI pipelines stay reproducible.
 
 ## Commit & Pull Request Guidelines
 Commits follow conventional prefixes (`feat`, `docs`, `chore`) with optional scopes
-(`feat(cli): ...`). Keep messages imperative and describe the observable behavior change. Each PR
+(`feat(cli): ...`). After the type/scope prefix, write the commit subject in sentence case. Keep messages imperative and describe the observable behavior change. Each PR
 should link issues when relevant, summarize CLI/UI impacts, note new league requirements, and attach
 sample outputs from `out/` if visuals changed. Ensure `uv run pytest`, `uv run black`, and
 `uv run ruff check` pass before requesting review.
@@ -41,5 +41,5 @@ sample outputs from `out/` if visuals changed. Ensure `uv run pytest`, `uv run b
 ## Security & Configuration Tips
 Never commit secrets; load ESPN credentials via `ESPN_USERNAME`/`ESPN_PASSWORD` or CLI flags.
 Regenerate Playwright storage with `uv run power-rankings --refresh` if sessions expire, and inspect
-saved auth state via `python debug_storage_state.py`. Keep `leagues.toml` IDs accurate and scrub
+saved auth state via `python debug_storage_state.py`. Keep `leagues.yaml` IDs accurate and scrub
 personally identifiable information from committed HTML captures.

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ tables, and expose those results through Typer entrypoints.
 
 - **Fetch or load HTML** – Every CLI funnels through `cli_common.ensure_schedule_or_exit`, which
   either validates a user-supplied HTML file or triggers Playwright-based scraping
-  (`web_fetch.download_schedule_html`) using credentials and league metadata from `leagues.toml`.
+  (`web_fetch.download_schedule_html`) using credentials and league metadata from `leagues.yaml`.
 - **Parse schedule tables** – `parse_utils.get_inputs` loads the stored HTML and uses PyQuery to walk
   the matchup tables. It emits a normalized pandas `DataFrame` with one row per team per week
   containing `team`, `opponent`, `score`, `opp_score`, derived `wins`, and the inferred `season`.
@@ -107,11 +107,11 @@ uv run playwright install chromium
 
 ### Configure leagues and credentials
 
-Map friendly league names to ESPN IDs in [`leagues.toml`](leagues.toml):
+Map friendly league names to ESPN IDs in [`leagues.yaml`](leagues.yaml):
 
-```toml
-[jlssffl]
-league_id = 329301
+```yaml
+example-league:
+  league_id: 123456
 ```
 
 Store ESPN credentials via environment variables or CLI flags:
@@ -122,17 +122,16 @@ export ESPN_PASSWORD="app-specific-password"
 ```
 
 Playwright caches login state in `~/.cache/power_rankings/espn_state.json`. If a stored session
-expires, re-run a command with `--headless/--no-headless` as needed or use
-[`debug_storage_state.py`](debug_storage_state.py) to inspect the saved state.
+expires, re-run a command with `--headless/--no-headless` as needed to refresh credentials.
 
 ### CLI quick reference
 
 | Command | Purpose | Example |
 | --- | --- | --- |
-| `power-rankings` | Single-season summary with optional plots | `uv run power-rankings --league jlssffl --season 2024 --out-dir out/2024` |
-| `all-time` | Aggregate multiple seasons | `uv run all-time 2019 2024 --league jlssffl --out-dir out/all-time` |
-| `team-spotlight` | Narrative of one owner’s season | `uv run team-spotlight "Matt Goldberg" --league jlssffl --season 2024 --out-dir out/spotlight` |
-| `team-season-rankings` | Cross-league, cross-season comparisons | `uv run team-season-rankings --league jlssffl --league hoedown --start-season 2018 --end-season 2024` |
+| `power-rankings` | Single-season summary with optional plots | `uv run power-rankings --league example-league --season 2024 --out-dir out/2024` |
+| `all-time` | Aggregate multiple seasons | `uv run all-time 2019 2024 --league example-league --out-dir out/all-time` |
+| `team-spotlight` | Narrative of one owner’s season | `uv run team-spotlight "Example Manager" --league example-league --season 2024 --out-dir out/spotlight` |
+| `team-season-rankings` | Cross-league, cross-season comparisons | `uv run team-season-rankings --league example-league --league showcase-league --start-season 2018 --end-season 2024` |
 
 All commands accept shared options from `cli_common.py`:
 
@@ -147,19 +146,19 @@ All commands accept shared options from `cli_common.py`:
 - Use local HTML and create charts:
 
   ```bash
-  uv run power-rankings html/jlssffl/2023.html --offline --out-dir out/2023
+  uv run power-rankings html/example-league/2023.html --offline --out-dir out/2023
   ```
 
 - Auto-fetch five years of data and print cumulative standings:
 
   ```bash
-  uv run all-time 2020 2024 --league jlssffl --download-dir html/jlssffl
+  uv run all-time 2020 2024 --league example-league --download-dir html/example-league
   ```
 
 - Compare every stored team season, sorted by `Proj` and limited to games through Week 10:
 
   ```bash
-  uv run team-season-rankings --league jlssffl --end-week 10 --sort-column Proj --sort-direction desc
+  uv run team-season-rankings --league example-league --end-week 10 --sort-column Proj --sort-direction desc
   ```
 
 ### Testing and quality checks
@@ -179,7 +178,6 @@ automation logic. Save generated plots to `out/` and keep deterministic fixtures
 
 - [Architecture overview](#architecture-overview) – Data flow, CLI interactions, and data model.
 - [AGENTS.md](AGENTS.md) – Repository conventions, testing requirements, and release expectations.
-- [`debug_storage_state.py`](debug_storage_state.py) – Diagnose Playwright login sessions.
 - [`tests/test_web_fetch.py`](tests/test_web_fetch.py) – Reference for stubbing ESPN scraping.
 - File an issue or start a discussion in the repository when you need new league metadata, CLI
   flags, or help debugging Playwright.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,6 +19,7 @@ dependencies = [
   "seaborn>=0.12.1,<0.13",
   "playwright>=1.47",
   "cyclopts>=4.2",
+  "pyyaml>=6.0.2",
 ]
 
 scripts.all-time = "power_rankings.all_time:cli"

--- a/src/power_rankings/cli_common.py
+++ b/src/power_rankings/cli_common.py
@@ -9,7 +9,7 @@ from typing import NoReturn, TextIO
 from cyclopts import Parameter
 from cyclopts.validators import Path as PathValidator
 
-from power_rankings.league_config import LeagueConfigError
+from power_rankings.league_config import LeagueConfigError, PRIMARY_CONFIG_NAME
 from power_rankings.web_fetch import (
     LoginAutomationError,
     MissingCredentialsError,
@@ -47,7 +47,7 @@ def offline_option() -> Parameter:
 
 def league_option() -> Parameter:
     return Parameter(
-        help="League name (from leagues.toml) used when downloading schedules.",
+        help=f"League name (from {PRIMARY_CONFIG_NAME}) used when downloading schedules.",
     )
 
 
@@ -72,7 +72,7 @@ def download_dir_option() -> Parameter:
 
 def leagues_file_option() -> Parameter:
     return Parameter(
-        help="Path to leagues.toml mapping league names to IDs.",
+        help=f"Path to {PRIMARY_CONFIG_NAME} mapping league names to IDs.",
         validator=PathValidator(dir_okay=False),
     )
 

--- a/src/power_rankings/cli_common.py
+++ b/src/power_rankings/cli_common.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 import logging
 import sys
 from datetime import date

--- a/src/power_rankings/league_config.py
+++ b/src/power_rankings/league_config.py
@@ -1,8 +1,27 @@
 from __future__ import annotations
 
+from collections.abc import Mapping
 from functools import lru_cache
 from pathlib import Path
-import tomllib
+from typing import Any, TypeAlias, TypedDict
+
+import yaml
+
+
+PRIMARY_CONFIG_NAME = "leagues.yaml"
+
+
+LeagueName: TypeAlias = str
+LeagueIdentifier: TypeAlias = int
+LeagueConfig = dict[LeagueName, LeagueIdentifier]
+
+
+class LeagueRecord(TypedDict, total=False):
+    league_id: LeagueIdentifier
+
+
+LeagueValue = LeagueIdentifier | str | LeagueRecord | None
+RawLeagueConfig: TypeAlias = dict[LeagueName, LeagueValue]
 
 
 class LeagueConfigError(RuntimeError):
@@ -18,24 +37,44 @@ class LeagueIdMismatchError(LeagueConfigError):
 
 
 @lru_cache
-def _load_from_path(path: Path) -> dict[str, int]:
-    with path.open("rb") as handle:
-        raw = tomllib.load(handle)
+def _load_from_path(path: Path) -> LeagueConfig:
+    with path.open("r", encoding="utf-8") as handle:
+        raw_data: Any = yaml.safe_load(handle) or {}
 
-    mapping: dict[str, int] = {}
-    for key, value in raw.items():
-        if isinstance(value, dict):
-            if "league_id" not in value:
-                raise LeagueConfigError(
-                    f"League '{key}' is missing 'league_id' in configuration file {path}."
-                )
-            mapping[key] = int(value["league_id"])
-        else:
-            mapping[key] = int(value)
+    if not isinstance(raw_data, Mapping):
+        raise LeagueConfigError(
+            f"Expected a mapping of league names in configuration file {path}, "
+            f"but found {type(raw_data).__name__}."
+        )
+
+    raw_config: RawLeagueConfig = dict(raw_data)
+
+    mapping: LeagueConfig = {}
+    for key, value in raw_config.items():
+        mapping[key] = _extract_league_id(key, value, path)
     return mapping
 
 
-def load_league_mapping(leagues_file: Path | None = None) -> dict[str, int]:
+def _extract_league_id(league_name: str, value: LeagueValue, path: Path) -> int:
+    record_value: Any
+    if isinstance(value, Mapping):
+        if "league_id" not in value:
+            raise LeagueConfigError(
+                f"League '{league_name}' is missing 'league_id' in configuration file {path}."
+            )
+        record_value = value["league_id"]
+    else:
+        record_value = value
+
+    try:
+        return int(record_value)
+    except (TypeError, ValueError) as exc:
+        raise LeagueConfigError(
+            f"League '{league_name}' has an invalid league_id value {record_value!r} in {path}."
+        ) from exc
+
+
+def load_league_mapping(leagues_file: Path | None = None) -> LeagueConfig:
     candidates = []
     if leagues_file is not None:
         specified = Path(leagues_file).expanduser()
@@ -46,10 +85,11 @@ def load_league_mapping(leagues_file: Path | None = None) -> dict[str, int]:
         cwd = Path.cwd().resolve()
         search_roots = (cwd,) + tuple(cwd.parents)
         for root in search_roots:
-            candidates.append(root / "leagues.toml")
-        package_default = Path(__file__).resolve().parent / "leagues.toml"
-        project_default = Path(__file__).resolve().parents[2] / "leagues.toml"
-        candidates.extend([package_default, project_default])
+            candidates.append(root / PRIMARY_CONFIG_NAME)
+        module_root = Path(__file__).resolve().parent
+        project_root = Path(__file__).resolve().parents[2]
+        candidates.append(module_root / PRIMARY_CONFIG_NAME)
+        candidates.append(project_root / PRIMARY_CONFIG_NAME)
 
     for candidate in candidates:
         if candidate.exists():
@@ -90,7 +130,7 @@ def resolve_league_id(
     mapping = load_league_mapping(leagues_file)
     if not mapping:
         raise LeagueConfigError(
-            "No leagues configuration found. Provide --league-id or create leagues.toml."
+            f"No leagues configuration found. Provide --league-id or create {PRIMARY_CONFIG_NAME}."
         )
 
     resolved = mapping.get(league_name)

--- a/src/power_rankings/league_config.py
+++ b/src/power_rankings/league_config.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 from collections.abc import Mapping
 from functools import lru_cache
 from pathlib import Path

--- a/src/power_rankings/name_utils.py
+++ b/src/power_rankings/name_utils.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 from typing import Any
 
 import pandas as pd

--- a/src/power_rankings/team_season_rankings.py
+++ b/src/power_rankings/team_season_rankings.py
@@ -17,7 +17,9 @@ logger = logging.getLogger(__name__)
 
 
 def main(
-    start_season: Annotated[int | None, Parameter(help="Earliest season (year) to include.")] = None,
+    start_season: Annotated[
+        int | None, Parameter(help="Earliest season (year) to include.")
+    ] = None,
     end_season: Annotated[int | None, Parameter(help="Latest season (year) to include.")] = None,
     leagues: Annotated[
         list[str] | None,

--- a/src/power_rankings/team_season_rankings.py
+++ b/src/power_rankings/team_season_rankings.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 import logging
 import re
 from pathlib import Path

--- a/src/power_rankings/team_season_rankings.py
+++ b/src/power_rankings/team_season_rankings.py
@@ -10,7 +10,7 @@ from cyclopts import Parameter, run
 from cyclopts.validators import Number
 
 from power_rankings import cli_common
-from power_rankings.league_config import load_league_mapping
+from power_rankings.league_config import PRIMARY_CONFIG_NAME, load_league_mapping
 from power_rankings.name_utils import canonicalize_team_names
 from power_rankings.parse_utils import get_inputs, most_recent_week
 from power_rankings.season_summary import get_summary_table
@@ -25,7 +25,7 @@ def main(
         list[str] | None,
         Parameter(
             name=("league", "-l"),
-            help="League name from leagues.toml. Repeat the option to include multiple leagues.",
+            help=f"League name from {PRIMARY_CONFIG_NAME}. Repeat the option to include multiple leagues.",
             show_default=False,
         ),
     ] = None,
@@ -162,7 +162,9 @@ def _resolve_leagues(
     mapping: dict[str, int],
 ) -> list[str]:
     if not mapping:
-        raise ValueError("No leagues are configured. Create leagues.toml or pass --leagues-file.")
+        raise ValueError(
+            f"No leagues are configured. Create {PRIMARY_CONFIG_NAME} or pass --leagues-file."
+        )
 
     if not requested:
         return sorted(mapping.keys())

--- a/src/power_rankings/web_fetch.py
+++ b/src/power_rankings/web_fetch.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 import logging
 import os
 from dataclasses import dataclass

--- a/uv.lock
+++ b/uv.lock
@@ -1295,6 +1295,7 @@ dependencies = [
     { name = "pandas" },
     { name = "playwright" },
     { name = "pyquery" },
+    { name = "pyyaml" },
     { name = "seaborn" },
 ]
 
@@ -1319,6 +1320,7 @@ requires-dist = [
     { name = "pandas", specifier = ">=1.5.2,<2" },
     { name = "playwright", specifier = ">=1.47" },
     { name = "pyquery", specifier = ">=0.13.2" },
+    { name = "pyyaml", specifier = ">=6.0.2" },
     { name = "seaborn", specifier = ">=0.12.1,<0.13" },
 ]
 


### PR DESCRIPTION
## Summary
- switch league configuration handling to YAML with explicit typing and error handling
- add PyYAML dependency, expand documentation, and ignore the local leagues file
- document the sentence-case commit subject requirement in AGENTS.md
- remove the unused typing import left over from the refactor and apply repo formatting fixes

## Testing
- uv run pytest
